### PR TITLE
devtools(common): add editorconfig support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 130
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false
+
+[COMMIT_EDITMSG]
+max_line_length = 72


### PR DESCRIPTION
### Ticket being worked
GitHub Issue: #13 

### Steps to reproduce
1. Open up any editor that has `editorconfig` file support, it should follow all of the rules.