### PR TITLE
fix(slider): add tooltips to param sliders

### DIFF
--- a/src/components/parameter-range-selector/index.js
+++ b/src/components/parameter-range-selector/index.js
@@ -1,9 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
-import { Range } from 'rc-slider'
+import Slider, { createSliderWithTooltip } from 'rc-slider'
 
 import './style.css'
+
+const Range = createSliderWithTooltip(Slider.Range)
 
 const styles = {
   root: {}
@@ -13,7 +15,10 @@ const ParameterRangeSelector = ({ classes, theme, ...props }) => (
   <Range
     className={classes.root}
     pushable={10}
+    min={0}
+    max={100}
     trackStyle={[{ backgroundColor: theme.palette.secondary.dark }]}
+    tipFormatter={value => `${value ? value / 10 : 0}`}
     handleStyle={[
       {
         backgroundColor: theme.palette.secondary.main,

--- a/src/components/parameter-range-selector/style.css
+++ b/src/components/parameter-range-selector/style.css
@@ -1,3 +1,18 @@
 .rc-slider-handle:active {
   box-shadow: 0 0 5px #5cf68a;
 }
+
+.rc-slider-tooltip {
+  z-index: 1;
+}
+
+.rc-slider-tooltip-inner {
+  background-color: #010318;
+  color: white;
+  font-family: Helvetica, sans-serif;
+  box-shadow: none;
+}
+
+.rc-slider-tooltip-placement-top .rc-slider-tooltip-arrow {
+  border-top-color: #010318;
+}


### PR DESCRIPTION
Adds tooltips to the parameters range sliders on the filters (and anywhere where those filters are being used)